### PR TITLE
Expand empire card

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -124,9 +124,6 @@ module.exports = function (/* ctx */) {
       lang: 'en-us', // Quasar language pack
       config: {
         dark: true,
-        loading: {
-          delay: 300,
-        },
       },
 
       // Possible values for "importStrategy":
@@ -148,7 +145,6 @@ module.exports = function (/* ctx */) {
       plugins: [
         'Meta',
         'LocalStorage',
-        'Loading',
       ],
     },
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,24 +1,18 @@
-import { Loading } from 'quasar'
-
 export const asyncRequestWithLoader = async ({
-  loadingMessage,
   tryCb,
   catchCb,
   finallyCb,
 } = {
-  loadingMessage: null,
   tryCb: null,
   catchCb: null,
   finallyCb: null,
 }) => {
-  loadingMessage ? Loading.show({ message: loadingMessage }) : null
   try {
     await tryCb()
   } catch (error) {
     catchCb ? await catchCb(error) : null
   } finally {
     finallyCb ? await finallyCb() : null
-    loadingMessage ? Loading.hide() : null
   }
 }
 

--- a/src/components/ActiveEmpireCard.vue
+++ b/src/components/ActiveEmpireCard.vue
@@ -13,12 +13,29 @@ export default {
   data: () => ({
     isGoodAvatar: true,
     isGoodEmpireImage: true,
+    descriptionIsOverflowing: false,
+    expanded: false,
   }),
   methods: {
     // TODO placeholder method for clicking on Active Empire Card
     doSomething() {
       console.log('test')
     },
+    checkIfOverflowing() {
+      if(this.$refs[this.descriptionRef].clientHeight < this.$refs[this.descriptionRef].scrollHeight) {
+        this.descriptionIsOverflowing = true
+      }
+    },
+  },
+  computed: {
+    descriptionRef() {
+      return `empire-${this.activeEmpire.id}description`
+    },
+  },
+  mounted() {
+    setTimeout(() => {
+      this.checkIfOverflowing()
+    }, 100)
   },
 }
 </script>
@@ -63,18 +80,23 @@ export default {
     />
 
     <q-card-section>
-      <div class="ellipsis-3-lines line-6-clamp">
+      <div
+        :ref="`empire-${activeEmpire.id}description`"
+        class="q-mb-md ellipsis-3-lines line-6-clamp"
+        :class="{'no-ellipsis': expanded }"
+      >
         {{ activeEmpire.galaxy.description }}
-        <q-tooltip
-          :delay="550"
-          max-width="18rem"
-          content-class="tooltip-font-size"
-          transition-show="scale"
-          transition-hide="scale"
-        >
-          {{ activeEmpire.galaxy.description }}
-        </q-tooltip>
       </div>
+      <q-btn
+        v-if="descriptionIsOverflowing"
+        color="white"
+        flat
+        dense
+        :icon="expanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down'"
+        @click.stop="expanded = !expanded"
+        :label="expanded ? 'COLLAPSE' : 'EXPAND'"
+        class="absolute-bottom full-width no-ripple text-body2"
+      />
     </q-card-section>
 
     <q-separator />
@@ -102,4 +124,7 @@ export default {
     outline: 1px solid $primary
 .line-6-clamp
   -webkit-line-clamp: 6
+.no-ellipsis
+  -webkit-line-clamp: initial
+  -webkit-box-orient: initial
 </style>

--- a/test/cypress/integration/gate.spec.js
+++ b/test/cypress/integration/gate.spec.js
@@ -46,4 +46,25 @@ describe('Gate', function () {
     cy.contains('FoohonPie').should('not.exist')
 
   })
+
+  it('user can expand and collapse overflowing description', () => {
+    cy.loginUser({
+      email: 'foo@bar.baz',
+      password: 'foobarbaz',
+    })
+    cy.verifyGatePage()
+
+    cy.contains('EXPAND').should('be.visible')
+    cy.contains('COLLAPSE').should('not.exist')
+
+    cy.contains('EXPAND').click()
+
+    cy.contains('EXPAND').should('not.exist')
+    cy.contains('COLLAPSE').should('be.visible')
+
+    cy.contains('COLLAPSE').click()
+
+    cy.contains('EXPAND').should('be.visible')
+    cy.contains('COLLAPSE').should('not.exist')
+  })
 })


### PR DESCRIPTION
This puts the Expand/Collapse behavior in place for only when the ActiveEmpire description overflows the content area. I had a bit of race-condition issue with occasionally the element's `clientHeight` and `scrollHeight` weren't "final" during the mounted lifecycle hook of the component.  I believe this is because Vue sometimes isn't fast enough to evaluate whether the container should have ellipsis or not (which effects height and thus the height calculation).

After trying $nextTick and still seeing the race condition sometimes show both of foo@bar.baz's cards as overflowing (only one actually was) I settled on a slightly heavier handed approach and just used `setTimeout` to delay the check by 100 milliseconds.  This consistently eliminates the race condition and I doubt anyone will notice the 100ms delay on first mount.

Second thing I did was remove the Loading plugin - I had started to include this in the last PR but ended up rolling it back.  However, I forgot to remove the plugin from the bundling.  I did that now.